### PR TITLE
Fix for test runner and spelling error

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,4 +2,4 @@
 
 This is a parser for the Path Syntax used in Falcor. It can be used to parse Falcor Path Syntax into an Array.
 
-[Grammer](spec/language.md)
+[Grammar](spec/language.md)

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
   },
   "homepage": "https://github.com/Netflix/falcor-path-syntax",
   "devDependencies": {
-    "chai": "~2.2.0"
+    "chai": "~2.2.0",
+    "mocha": "^2.3.0"
   },
   "dependencies": {}
 }


### PR DESCRIPTION
Adds mocha to dev dependencies so after npm install, npm run test will work. Also fixes a small spelling error in readme.md.

I was going to begin looking into supporting template strings and noticed these two small things upon cloning the repo and figured they would be better as a separate PR rather than lumped in with a feature.