### PR TITLE
Declare var done, to fix compatability with Node 4.x

### DIFF
--- a/src/tokenizer/index.js
+++ b/src/tokenizer/index.js
@@ -66,6 +66,7 @@ function toOutput(token, type, done) {
 function getNext(string, idx, ext) {
     var output = false;
     var token = '';
+    var done;
     var specialChars = ext ?
         EXT_SPECIAL_CHARACTERS : SPECIAL_CHARACTERS;
     do {
@@ -146,5 +147,3 @@ function getNext(string, idx, ext) {
         idx: idx
     };
 }
-
-


### PR DESCRIPTION
Running Falcor on `node 4.1.2`, in strict mode, I was getting the following stack error:

```
ReferenceError: done is not defined
    at getNext (/Users/sean.owiecki/development/project/node_modules/falcor-router/node_modules/falcor-path-syntax/src/tokenizer/index.js:72:13)
...
```

Throwing in this declaration seems to fix it.