### PR TITLE
Prevent variables from leaking

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -17,7 +17,7 @@ parser.fromPathsOrPathValues = function(paths, ext) {
     }
 
     var out = [];
-    for (i = 0, len = paths.length; i < len; i++) {
+    for (var i = 0, len = paths.length; i < len; i++) {
 
         // Is the path a string
         if (typeof paths[i] === 'string') {


### PR DESCRIPTION
`i` and `len` aren't declared, and the file/function aren't running in strict mode, so those two are leaking into the global scope. Fixed by simply declaring them w/ `var`.

This came up because our build broke when using `falcor-router` on the client because it checks all build output with [leaky](https://www.npmjs.com/package/leaky).

If this doesn't match your syntax/style rules or isn't actually a problem for some reason I'm not aware of feel free to close.