### PR TITLE
Use ES6 syntax and add support for eslint

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,4 @@
+{
+  "presets": ["es2015"],
+  "plugins": ["transform-class-properties"]
+}

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,11 @@
+{
+    "rules": {
+        "comma-dangle": [1, "always-multiline"],
+        "no-fallthrough": 1
+    },
+    "env": {
+        "es6": true,
+        "node": true
+    },
+    "extends": ["eslint:recommended"]
+}

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 node_modules
 .idea
 *.iml
+lib

--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,3 @@
 node_modules
 .idea
 *.iml
-lib

--- a/lib/RoutedTokens.js
+++ b/lib/RoutedTokens.js
@@ -1,0 +1,7 @@
+'use strict';
+
+module.exports = {
+    integers: 'integers',
+    ranges: 'ranges',
+    keys: 'keys'
+};

--- a/lib/TokenTypes.js
+++ b/lib/TokenTypes.js
@@ -1,0 +1,18 @@
+'use strict';
+
+var TokenTypes = {
+    token: 'token',
+    dotSeparator: '.',
+    commaSeparator: ',',
+    openingBracket: '[',
+    closingBracket: ']',
+    openingBrace: '{',
+    closingBrace: '}',
+    escape: '\\',
+    space: ' ',
+    colon: ':',
+    quote: 'quote',
+    unknown: 'unknown'
+};
+
+module.exports = TokenTypes;

--- a/lib/exceptions/index.js
+++ b/lib/exceptions/index.js
@@ -1,0 +1,33 @@
+'use strict';
+
+module.exports = {
+    indexer: {
+        nested: 'Indexers cannot be nested.',
+        needQuotes: 'unquoted indexers must be numeric.',
+        empty: 'cannot have empty indexers.',
+        leadingDot: 'Indexers cannot have leading dots.',
+        leadingComma: 'Indexers cannot have leading comma.',
+        requiresComma: 'Indexers require commas between indexer args.',
+        routedTokens: 'Only one token can be used per indexer when specifying routed tokens.'
+    },
+    range: {
+        precedingNaN: 'ranges must be preceded by numbers.',
+        suceedingNaN: 'ranges must be suceeded by numbers.'
+    },
+    routed: {
+        invalid: 'Invalid routed token.  only integers|ranges|keys are supported.'
+    },
+    quote: {
+        empty: 'cannot have empty quoted keys.',
+        illegalEscape: 'Invalid escape character.  Only quotes are escapable.'
+    },
+    unexpectedToken: 'Unexpected token.',
+    invalidIdentifier: 'Invalid Identifier.',
+    invalidPath: 'Please provide a valid path.',
+    throwError: function throwError(err, tokenizer, token) {
+        if (token) {
+            throw err + ' -- ' + tokenizer.parseString + ' with next token: ' + token;
+        }
+        throw err + ' -- ' + tokenizer.parseString;
+    }
+};

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,0 +1,61 @@
+'use strict';
+
+var Tokenizer = require('./tokenizer');
+var head = require('./parse-tree/head');
+var RoutedTokens = require('./RoutedTokens');
+
+var parser = function parser(string, extendedRules) {
+    return head(new Tokenizer(string, extendedRules));
+};
+
+module.exports = parser;
+
+// Constructs the paths from paths / pathValues that have strings.
+// If it does not have a string, just moves the value into the return
+// results.
+parser.fromPathsOrPathValues = function (paths, ext) {
+    if (!paths) {
+        return [];
+    }
+
+    var out = [];
+    for (var i = 0, len = paths.length; i < len; i++) {
+
+        // Is the path a string
+        if (typeof paths[i] === 'string') {
+            out[i] = parser(paths[i], ext);
+        }
+
+        // is the path a path value with a string value.
+        else if (typeof paths[i].path === 'string') {
+                out[i] = {
+                    path: parser(paths[i].path, ext),
+                    value: paths[i].value
+                };
+            }
+
+            // just copy it over.
+            else {
+                    out[i] = paths[i];
+                }
+    }
+
+    return out;
+};
+
+// If the argument is a string, this with convert, else just return
+// the path provided.
+parser.fromPath = function (path, ext) {
+    if (!path) {
+        return [];
+    }
+
+    if (typeof path === 'string') {
+        return parser(path, ext);
+    }
+
+    return path;
+};
+
+// Potential routed tokens.
+parser.RoutedTokens = RoutedTokens;

--- a/lib/parse-tree/head.js
+++ b/lib/parse-tree/head.js
@@ -1,0 +1,59 @@
+'use strict';
+
+var TokenTypes = require('./../TokenTypes');
+var E = require('./../exceptions');
+var indexer = require('./indexer');
+
+/**
+ * The top level of the parse tree.  This returns the generated path
+ * from the tokenizer.
+ */
+module.exports = function head(tokenizer) {
+    var token = tokenizer.next();
+    var state = {};
+    var out = [];
+
+    while (!token.done) {
+
+        switch (token.type) {
+            case TokenTypes.token:
+                var first = +token.token[0];
+                if (!isNaN(first)) {
+                    E.throwError(E.invalidIdentifier, tokenizer);
+                }
+                out[out.length] = token.token;
+                break;
+
+            // dotSeparators at the top level have no meaning
+            case TokenTypes.dotSeparator:
+                if (out.length === 0) {
+                    E.throwError(E.unexpectedToken, tokenizer);
+                }
+                break;
+
+            // Spaces do nothing.
+            case TokenTypes.space:
+                // NOTE: Spaces at the top level are allowed.
+                // titlesById  .summary is a valid path.
+                break;
+
+            // Its time to decend the parse tree.
+            case TokenTypes.openingBracket:
+                indexer(tokenizer, token, state, out);
+                break;
+
+            default:
+                E.throwError(E.unexpectedToken, tokenizer);
+                break;
+        }
+
+        // Keep cycling through the tokenizer.
+        token = tokenizer.next();
+    }
+
+    if (out.length === 0) {
+        E.throwError(E.invalidPath, tokenizer);
+    }
+
+    return out;
+};

--- a/lib/parse-tree/indexer.js
+++ b/lib/parse-tree/indexer.js
@@ -1,0 +1,112 @@
+'use strict';
+
+var TokenTypes = require('./../TokenTypes');
+var E = require('./../exceptions');
+var idxE = E.indexer;
+var range = require('./range');
+var quote = require('./quote');
+var routed = require('./routed');
+
+/**
+ * The indexer is all the logic that happens in between
+ * the '[', opening bracket, and ']' closing bracket.
+ */
+module.exports = function indexer(tokenizer, openingToken, state, out) {
+    var token = tokenizer.next();
+    var done = false;
+    var allowedMaxLength = 1;
+    var routedIndexer = false;
+
+    // State variables
+    state.indexer = [];
+
+    while (!token.done) {
+
+        switch (token.type) {
+            case TokenTypes.token:
+            case TokenTypes.quote:
+
+                // ensures that token adders are properly delimited.
+                if (state.indexer.length === allowedMaxLength) {
+                    E.throwError(idxE.requiresComma, tokenizer);
+                }
+                break;
+        }
+
+        switch (token.type) {
+            // Extended syntax case
+            case TokenTypes.openingBrace:
+                routedIndexer = true;
+                routed(tokenizer, token, state, out);
+                break;
+
+            case TokenTypes.token:
+                var t = +token.token;
+                if (isNaN(t)) {
+                    E.throwError(idxE.needQuotes, tokenizer);
+                }
+                state.indexer[state.indexer.length] = t;
+                break;
+
+            // dotSeparators at the top level have no meaning
+            case TokenTypes.dotSeparator:
+                if (!state.indexer.length) {
+                    E.throwError(idxE.leadingDot, tokenizer);
+                }
+                range(tokenizer, token, state, out);
+                break;
+
+            // Spaces do nothing.
+            case TokenTypes.space:
+                break;
+
+            case TokenTypes.closingBracket:
+                done = true;
+                break;
+
+            // The quotes require their own tree due to what can be in it.
+            case TokenTypes.quote:
+                quote(tokenizer, token, state, out);
+                break;
+
+            // Its time to decend the parse tree.
+            case TokenTypes.openingBracket:
+                E.throwError(idxE.nested, tokenizer);
+                break;
+
+            case TokenTypes.commaSeparator:
+                ++allowedMaxLength;
+                break;
+
+            default:
+                E.throwError(E.unexpectedToken, tokenizer);
+                break;
+        }
+
+        // If done, leave loop
+        if (done) {
+            break;
+        }
+
+        // Keep cycling through the tokenizer.
+        token = tokenizer.next();
+    }
+
+    if (state.indexer.length === 0) {
+        E.throwError(idxE.empty, tokenizer);
+    }
+
+    if (state.indexer.length > 1 && routedIndexer) {
+        E.throwError(idxE.routedTokens, tokenizer);
+    }
+
+    // Remember, if an array of 1, keySets will be generated.
+    if (state.indexer.length === 1) {
+        state.indexer = state.indexer[0];
+    }
+
+    out[out.length] = state.indexer;
+
+    // Clean state.
+    state.indexer = undefined;
+};

--- a/lib/parse-tree/quote.js
+++ b/lib/parse-tree/quote.js
@@ -1,0 +1,82 @@
+'use strict';
+
+var TokenTypes = require('./../TokenTypes');
+var E = require('./../exceptions');
+var quoteE = E.quote;
+
+/**
+ * quote is all the parse tree in between quotes.  This includes the only
+ * escaping logic.
+ *
+ * parse-tree:
+ * <opening-quote>(.|(<escape><opening-quote>))*<opening-quote>
+ */
+module.exports = function quote(tokenizer, openingToken, state) {
+    var token = tokenizer.next();
+    var innerToken = '';
+    var openingQuote = openingToken.token;
+    var escaping = false;
+    var done = false;
+
+    while (!token.done) {
+
+        switch (token.type) {
+            case TokenTypes.token:
+            case TokenTypes.space:
+
+            case TokenTypes.dotSeparator:
+            case TokenTypes.commaSeparator:
+
+            case TokenTypes.openingBracket:
+            case TokenTypes.closingBracket:
+            case TokenTypes.openingBrace:
+            case TokenTypes.closingBrace:
+                if (escaping) {
+                    E.throwError(quoteE.illegalEscape, tokenizer);
+                }
+
+                innerToken += token.token;
+                break;
+
+            case TokenTypes.quote:
+                // the simple case.  We are escaping
+                if (escaping) {
+                    innerToken += token.token;
+                    escaping = false;
+                }
+
+                // its not a quote that is the opening quote
+                else if (token.token !== openingQuote) {
+                        innerToken += token.token;
+                    }
+
+                    // last thing left.  Its a quote that is the opening quote
+                    // therefore we must produce the inner token of the indexer.
+                    else {
+                            done = true;
+                        }
+
+                break;
+            case TokenTypes.escape:
+                escaping = true;
+                break;
+
+            default:
+                E.throwError(E.unexpectedToken, tokenizer);
+        }
+
+        // If done, leave loop
+        if (done) {
+            break;
+        }
+
+        // Keep cycling through the tokenizer.
+        token = tokenizer.next();
+    }
+
+    if (innerToken.length === 0) {
+        E.throwError(quoteE.empty, tokenizer);
+    }
+
+    state.indexer[state.indexer.length] = innerToken;
+};

--- a/lib/parse-tree/range.js
+++ b/lib/parse-tree/range.js
@@ -1,0 +1,83 @@
+'use strict';
+
+var Tokenizer = require('./../tokenizer');
+var TokenTypes = require('./../TokenTypes');
+var E = require('./../exceptions');
+
+/**
+ * The range logic.
+ *
+ * parse-tree:
+ * <index>(..|...)<index>
+ */
+module.exports = function range(tokenizer, openingToken, state) {
+    var token = tokenizer.peek();
+    var dotCount = 1;
+    var done = false;
+    var inclusive = true;
+
+    // Grab the last token off the stack.  Must be an integer.
+    var idx = state.indexer.length - 1;
+    var from = Tokenizer.toNumber(state.indexer[idx]);
+    var to;
+
+    if (isNaN(from)) {
+        E.throwError(E.range.precedingNaN, tokenizer);
+    }
+
+    // Why is number checking so difficult in javascript.
+
+    while (!done && !token.done) {
+
+        switch (token.type) {
+
+            // dotSeparators at the top level have no meaning
+            case TokenTypes.dotSeparator:
+                if (dotCount === 3) {
+                    E.throwError(E.unexpectedToken, tokenizer);
+                }
+                ++dotCount;
+
+                if (dotCount === 3) {
+                    inclusive = false;
+                }
+                break;
+
+            case TokenTypes.token:
+                // move the tokenizer forward and save to.
+                to = Tokenizer.toNumber(tokenizer.next().token);
+
+                // throw potential error.
+                if (isNaN(to)) {
+                    E.throwError(E.range.suceedingNaN, tokenizer);
+                }
+
+                done = true;
+                break;
+
+            default:
+                done = true;
+                break;
+        }
+
+        // Keep cycling through the tokenizer.  But ranges have to peek
+        // before they go to the next token since there is no 'terminating'
+        // character.
+        if (!done) {
+            tokenizer.next();
+
+            // go to the next token without consuming.
+            token = tokenizer.peek();
+        }
+
+        // break and remove state information.
+        else {
+                break;
+            }
+    }
+
+    state.indexer[idx] = {
+        from: from,
+        to: inclusive ? to : to - 1
+    };
+};

--- a/lib/parse-tree/routed.js
+++ b/lib/parse-tree/routed.js
@@ -1,0 +1,75 @@
+'use strict';
+
+var TokenTypes = require('./../TokenTypes');
+var RoutedTokens = require('./../RoutedTokens');
+var E = require('./../exceptions');
+var routedE = E.routed;
+
+/**
+ * The routing logic.
+ *
+ * parse-tree:
+ * <opening-brace><routed-token>(:<token>)<closing-brace>
+ */
+module.exports = function routed(tokenizer, openingToken, state) {
+    var routeToken = tokenizer.next();
+    var named = false;
+    var name = '';
+
+    // ensure the routed token is a valid ident.
+    switch (routeToken.token) {
+        case RoutedTokens.integers:
+        case RoutedTokens.ranges:
+        case RoutedTokens.keys:
+            //valid
+            break;
+        default:
+            E.throwError(routedE.invalid, tokenizer);
+            break;
+    }
+
+    // Now its time for colon or ending brace.
+    var next = tokenizer.next();
+
+    // we are parsing a named identifier.
+    if (next.type === TokenTypes.colon) {
+        named = true;
+
+        // Get the token name or a white space character.
+        next = tokenizer.next();
+
+        // Skip over preceeding white space
+        while (next.type === TokenTypes.space) {
+            next = tokenizer.next();
+        }
+
+        if (next.type !== TokenTypes.token) {
+            E.throwError(routedE.invalid, tokenizer);
+        }
+        name = next.token;
+
+        // Move to the closing brace or white space character
+        next = tokenizer.next();
+
+        // Skip over any white space to get to the closing brace
+        while (next.type === TokenTypes.space) {
+            next = tokenizer.next();
+        }
+    }
+
+    // must close with a brace.
+
+    if (next.type === TokenTypes.closingBrace) {
+        var outputToken = {
+            type: routeToken.token,
+            named: named,
+            name: name
+        };
+        state.indexer[state.indexer.length] = outputToken;
+    }
+
+    // closing brace expected
+    else {
+            E.throwError(routedE.invalid, tokenizer);
+        }
+};

--- a/lib/tokenizer/index.js
+++ b/lib/tokenizer/index.js
@@ -1,0 +1,171 @@
+'use strict';
+
+var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+var TokenTypes = require('./../TokenTypes');
+
+var DOT_SEPARATOR = '.';
+var COMMA_SEPARATOR = ',';
+var OPENING_BRACKET = '[';
+var CLOSING_BRACKET = ']';
+var OPENING_BRACE = '{';
+var CLOSING_BRACE = '}';
+var COLON = ':';
+var ESCAPE = '\\';
+var DOUBLE_OUOTES = '"';
+var SINGE_OUOTES = "'";
+var TAB = "\t";
+var SPACE = " ";
+var LINE_FEED = '\n';
+var CARRIAGE_RETURN = '\r';
+var SPECIAL_CHARACTERS = '\\\'"[]., \t\n\r';
+var EXT_SPECIAL_CHARACTERS = '\\{}\'"[]., :\t\n\r';
+
+module.exports = function () {
+    function Tokenizer(string, ext) {
+        _classCallCheck(this, Tokenizer);
+
+        this._string = string;
+        this._idx = -1;
+        this._extended = ext;
+        this.parseString = '';
+    }
+
+    /**
+     * grabs the next token either from the peek operation or generates the
+     * next token.
+     */
+
+
+    _createClass(Tokenizer, [{
+        key: 'next',
+        value: function next() {
+            var nextToken = this._nextToken || getNext(this._string, this._idx, this._extended);
+
+            this._idx = nextToken.idx;
+            this._nextToken = false;
+            this.parseString += nextToken.token.token;
+
+            return nextToken.token;
+        }
+
+        /**
+         * will peak but not increment the tokenizer
+         */
+
+    }, {
+        key: 'peek',
+        value: function peek() {
+            this._nextToken = this._nextToken || getNext(this._string, this._idx, this._extended);
+
+            return this._nextToken.token;
+        }
+    }], [{
+        key: 'toNumber',
+        value: function toNumber(x) {
+            if (!isNaN(+x)) {
+                return +x;
+            }
+            return NaN;
+        }
+    }]);
+
+    return Tokenizer;
+}();
+
+function toOutput(token, type, done) {
+    return {
+        token: token,
+        done: done,
+        type: type
+    };
+}
+
+function getNext(string, idx, ext) {
+    var output = false;
+    var token = '';
+    var specialChars = ext ? EXT_SPECIAL_CHARACTERS : SPECIAL_CHARACTERS;
+    var done;
+
+    do {
+
+        done = idx + 1 >= string.length;
+        if (done) {
+            break;
+        }
+
+        // we have to peek at the next token
+        var character = string[idx + 1];
+
+        if (character !== undefined && specialChars.indexOf(character) === -1) {
+
+            token += character;
+            ++idx;
+            continue;
+        }
+
+        // The token to delimiting character transition.
+        else if (token.length) {
+                break;
+            }
+
+        ++idx;
+        var type;
+        switch (character) {
+            case DOT_SEPARATOR:
+                type = TokenTypes.dotSeparator;
+                break;
+            case COMMA_SEPARATOR:
+                type = TokenTypes.commaSeparator;
+                break;
+            case OPENING_BRACKET:
+                type = TokenTypes.openingBracket;
+                break;
+            case CLOSING_BRACKET:
+                type = TokenTypes.closingBracket;
+                break;
+            case OPENING_BRACE:
+                type = TokenTypes.openingBrace;
+                break;
+            case CLOSING_BRACE:
+                type = TokenTypes.closingBrace;
+                break;
+            case TAB:
+            case SPACE:
+            case LINE_FEED:
+            case CARRIAGE_RETURN:
+                type = TokenTypes.space;
+                break;
+            case DOUBLE_OUOTES:
+            case SINGE_OUOTES:
+                type = TokenTypes.quote;
+                break;
+            case ESCAPE:
+                type = TokenTypes.escape;
+                break;
+            case COLON:
+                type = TokenTypes.colon;
+                break;
+            default:
+                type = TokenTypes.unknown;
+                break;
+        }
+        output = toOutput(character, type, false);
+        break;
+    } while (!done);
+
+    if (!output && token.length) {
+        output = toOutput(token, TokenTypes.token, false);
+    }
+
+    if (!output) {
+        output = { done: true };
+    }
+
+    return {
+        token: output,
+        idx: idx
+    };
+}

--- a/package.json
+++ b/package.json
@@ -2,12 +2,13 @@
   "name": "falcor-path-syntax",
   "version": "0.2.4",
   "description": "Parser for Falcor Path Syntax",
-  "main": "src/index.js",
+  "main": "lib/index.js",
   "directories": {
     "test": "test"
   },
   "scripts": {
-    "test": "mocha test/index.js"
+    "es5": "babel src --out-dir lib",
+    "test": "mocha --compilers js:babel-core/register test/index.js"
   },
   "repository": {
     "type": "git",
@@ -25,6 +26,10 @@
   },
   "homepage": "https://github.com/Netflix/falcor-path-syntax",
   "devDependencies": {
+    "babel-cli": "^6.10.1",
+    "babel-core": "^6.9.1",
+    "babel-plugin-transform-class-properties": "^6.9.1",
+    "babel-preset-es2015": "^6.9.0",
     "chai": "~2.2.0",
     "mocha": "^2.3.0"
   },

--- a/src/RoutedTokens.js
+++ b/src/RoutedTokens.js
@@ -1,5 +1,5 @@
 module.exports = {
     integers: 'integers',
     ranges: 'ranges',
-    keys: 'keys'
+    keys: 'keys',
 };

--- a/src/TokenTypes.js
+++ b/src/TokenTypes.js
@@ -10,7 +10,7 @@ var TokenTypes = {
     space: ' ',
     colon: ':',
     quote: 'quote',
-    unknown: 'unknown'
+    unknown: 'unknown',
 };
 
 module.exports = TokenTypes;

--- a/src/exceptions/index.js
+++ b/src/exceptions/index.js
@@ -6,27 +6,26 @@ module.exports = {
         leadingDot: 'Indexers cannot have leading dots.',
         leadingComma: 'Indexers cannot have leading comma.',
         requiresComma: 'Indexers require commas between indexer args.',
-        routedTokens: 'Only one token can be used per indexer when specifying routed tokens.'
+        routedTokens: 'Only one token can be used per indexer when specifying routed tokens.',
     },
     range: {
         precedingNaN: 'ranges must be preceded by numbers.',
-        suceedingNaN: 'ranges must be suceeded by numbers.'
+        suceedingNaN: 'ranges must be suceeded by numbers.',
     },
     routed: {
-        invalid: 'Invalid routed token.  only integers|ranges|keys are supported.'
+        invalid: 'Invalid routed token.  only integers|ranges|keys are supported.',
     },
     quote: {
         empty: 'cannot have empty quoted keys.',
-        illegalEscape: 'Invalid escape character.  Only quotes are escapable.'
+        illegalEscape: 'Invalid escape character.  Only quotes are escapable.',
     },
     unexpectedToken: 'Unexpected token.',
     invalidIdentifier: 'Invalid Identifier.',
     invalidPath: 'Please provide a valid path.',
     throwError: function(err, tokenizer, token) {
         if (token) {
-            throw err + ' -- ' + tokenizer.parseString + ' with next token: ' + token;
+            throw `${err} -- ${tokenizer.parseString} with next token: ${token}`;
         }
-        throw err + ' -- ' + tokenizer.parseString;
-    }
+        throw `${err} -- ${tokenizer.parseString}`;
+    },
 };
-

--- a/src/index.js
+++ b/src/index.js
@@ -27,7 +27,8 @@ parser.fromPathsOrPathValues = function(paths, ext) {
         // is the path a path value with a string value.
         else if (typeof paths[i].path === 'string') {
             out[i] = {
-                path: parser(paths[i].path, ext), value: paths[i].value
+                path: parser(paths[i].path, ext),
+                value: paths[i].value,
             };
         }
 

--- a/src/parse-tree/quote.js
+++ b/src/parse-tree/quote.js
@@ -9,7 +9,7 @@ var quoteE = E.quote;
  * parse-tree:
  * <opening-quote>(.|(<escape><opening-quote>))*<opening-quote>
  */
-module.exports = function quote(tokenizer, openingToken, state, out) {
+module.exports = function quote(tokenizer, openingToken, state) {
     var token = tokenizer.next();
     var innerToken = '';
     var openingQuote = openingToken.token;
@@ -79,4 +79,3 @@ module.exports = function quote(tokenizer, openingToken, state, out) {
 
     state.indexer[state.indexer.length] = innerToken;
 };
-

--- a/src/parse-tree/range.js
+++ b/src/parse-tree/range.js
@@ -3,10 +3,12 @@ var TokenTypes = require('./../TokenTypes');
 var E = require('./../exceptions');
 
 /**
- * The indexer is all the logic that happens in between
- * the '[', opening bracket, and ']' closing bracket.
+ * The range logic.
+ *
+ * parse-tree:
+ * <index>(..|...)<index>
  */
-module.exports = function range(tokenizer, openingToken, state, out) {
+module.exports = function range(tokenizer, openingToken, state) {
     var token = tokenizer.peek();
     var dotCount = 1;
     var done = false;
@@ -72,6 +74,8 @@ module.exports = function range(tokenizer, openingToken, state, out) {
         }
     }
 
-    state.indexer[idx] = {from: from, to: inclusive ? to : to - 1};
+    state.indexer[idx] = {
+      from: from,
+      to: inclusive ? to : to - 1,
+    };
 };
-

--- a/src/parse-tree/routed.js
+++ b/src/parse-tree/routed.js
@@ -9,7 +9,7 @@ var routedE = E.routed;
  * parse-tree:
  * <opening-brace><routed-token>(:<token>)<closing-brace>
  */
-module.exports = function routed(tokenizer, openingToken, state, out) {
+module.exports = function routed(tokenizer, openingToken, state) {
     var routeToken = tokenizer.next();
     var named = false;
     var name = '';
@@ -61,7 +61,7 @@ module.exports = function routed(tokenizer, openingToken, state, out) {
         var outputToken = {
             type: routeToken.token,
             named: named,
-            name: name
+            name: name,
         };
         state.indexer[state.indexer.length] = outputToken;
     }
@@ -72,4 +72,3 @@ module.exports = function routed(tokenizer, openingToken, state, out) {
     }
 
 };
-

--- a/src/tokenizer/index.js
+++ b/src/tokenizer/index.js
@@ -1,4 +1,5 @@
 var TokenTypes = require('./../TokenTypes');
+
 var DOT_SEPARATOR = '.';
 var COMMA_SEPARATOR = ',';
 var OPENING_BRACKET = '[';
@@ -16,46 +17,44 @@ var CARRIAGE_RETURN = '\r';
 var SPECIAL_CHARACTERS = '\\\'"[]., \t\n\r';
 var EXT_SPECIAL_CHARACTERS = '\\{}\'"[]., :\t\n\r';
 
-var Tokenizer = module.exports = function(string, ext) {
-    this._string = string;
-    this._idx = -1;
-    this._extended = ext;
-    this.parseString = '';
-};
+module.exports = class Tokenizer {
 
-Tokenizer.prototype = {
+    constructor(string, ext) {
+        this._string = string;
+        this._idx = -1;
+        this._extended = ext;
+        this.parseString = '';
+    }
+
     /**
      * grabs the next token either from the peek operation or generates the
      * next token.
      */
-    next: function() {
-        var nextToken = this._nextToken ?
-            this._nextToken : getNext(this._string, this._idx, this._extended);
+    next() {
+        var nextToken = this._nextToken || getNext(this._string, this._idx, this._extended);
 
         this._idx = nextToken.idx;
         this._nextToken = false;
         this.parseString += nextToken.token.token;
 
         return nextToken.token;
-    },
+    }
 
     /**
      * will peak but not increment the tokenizer
      */
-    peek: function() {
-        var nextToken = this._nextToken ?
-            this._nextToken : getNext(this._string, this._idx, this._extended);
-        this._nextToken = nextToken;
+    peek() {
+        this._nextToken = this._nextToken || getNext(this._string, this._idx, this._extended);
 
-        return nextToken.token;
+        return this._nextToken.token;
     }
-};
 
-Tokenizer.toNumber = function toNumber(x) {
-    if (!isNaN(+x)) {
-        return +x;
+    static toNumber(x) {
+        if (!isNaN(+x)) {
+            return +x;
+        }
+        return NaN;
     }
-    return NaN;
 };
 
 function toOutput(token, type, done) {
@@ -154,5 +153,3 @@ function getNext(string, idx, ext) {
         idx: idx
     };
 }
-
-


### PR DESCRIPTION
The es6 features I used:
- The new class syntax (instead of manually setting prototype).
- The new template string (instead of concatenating strings).

Using eslint, I was able to remove few unused arguments.
I also corrected the description of `parse-tree/range` which was mistakenly copied from the indexer.

To transpile es6 code into es5-compatible code, do `npm run es5`. It uses babel to transpile all files from `src/` into `lib/`.
