### PR TITLE
Throw a new Error() instead of throwing a string

### DIFF
--- a/src/exceptions/index.js
+++ b/src/exceptions/index.js
@@ -23,10 +23,9 @@ module.exports = {
     invalidIdentifier: 'Invalid Identifier.',
     invalidPath: 'Please provide a valid path.',
     throwError: function(err, tokenizer, token) {
-        if (token) {
-            throw err + ' -- ' + tokenizer.parseString + ' with next token: ' + token;
-        }
-        throw err + ' -- ' + tokenizer.parseString;
+        var baseMessage = err + ' -- ' + tokenizer.parseString;
+        var message = token ? baseMessage + ' with next token: ' + token : baseMessage;
+        var error = new Error(message);
+        throw error;
     }
 };
-

--- a/test/parse-tree/parser.spec.js
+++ b/test/parse-tree/parser.spec.js
@@ -124,7 +124,7 @@ describe('#errors', function() {
             out = parser('one[{ranges:f o o}].oneMore', true);
         } catch (e) {
             out = undefined;
-            expect(e.substr(0, errText.length)).to.equal(errText);
+            expect(e.message.substr(0, errText.length)).to.equal(errText);
         }
         expect(out).to.equal(undefined);
     });


### PR DESCRIPTION
Stack traces weren't appearing in my logs, that's why I noticed this.